### PR TITLE
Apply mask before checking string length to see if entire message is rec...

### DIFF
--- a/websockets.php
+++ b/websockets.php
@@ -387,14 +387,14 @@ abstract class WebSocketServer {
       return false;
     }
     if (extension_loaded('mbstring')) {
-      if ($headers['length'] > mb_strlen($payload)) {
+      if ($headers['length'] > mb_strlen($this->applyMask($headers,$payload))) {
         $user->handlingPartialPacket = true;
         $user->partialBuffer = $message;
         return false;
       }
     } 
     else {
-      if ($headers['length'] > strlen($payload)) {
+      if ($headers['length'] > strlen($this->applyMask($headers,$payload))) {
         $user->handlingPartialPacket = true;
         $user->partialBuffer = $message;
         return false;


### PR DESCRIPTION
...eived

Resolves issue #16, where multi-byte encoded messages were sometimes reporting a length less than the length reported by the message's headers.  Applied to non-mbstring logic branch for consistency.
