### PR TITLE
Dev legacy mb_encoding not present for everyone fix

### DIFF
--- a/websockets.php
+++ b/websockets.php
@@ -366,15 +366,11 @@ abstract class WebSocketServer {
         if ($user->hasSentClose) {
           $this->disconnect($user);
         } else {
-          if (function_exists('mb_check_encoding')) {
-            if (mb_check_encoding($message,'UTF-8')) { 
-              $this->process($user, $message);
-            } else {
-              $this->stderr("not UTF-8\n");
-            }
-          }
-          else {
+          if (preg_match('//u', $message)) {
+            //$this->stdout("Is UTF-8\n".$message); 
             $this->process($user, $message);
+          } else {
+            $this->stderr("not UTF-8\n");
           }
         }
       } 


### PR DESCRIPTION
I have allready see this in major revision and put a fix to that.

Your solution, have a hole in it in event the user did not have mb extensions there is no validation encoding could lead in various error.